### PR TITLE
Update get jobs ordering

### DIFF
--- a/pkg/db/pgdao/jobs.sql.go
+++ b/pkg/db/pgdao/jobs.sql.go
@@ -220,7 +220,7 @@ select
     from jobs j
     join persons p on p.id = j.created_by
     where j.blocked_at is null and j.suspended_at is null
-    order by j.created_at desc
+    order by j.updated_at desc
 `
 
 type JobsListRow struct {

--- a/pkg/db/sqlc/queries/jobs.sql
+++ b/pkg/db/sqlc/queries/jobs.sql
@@ -14,7 +14,7 @@ select
     from jobs j
     join persons p on p.id = j.created_by
     where j.blocked_at is null and j.suspended_at is null
-    order by j.created_at desc;
+    order by j.updated_at desc;
 
 -- name: JobGet :one
 select


### PR DESCRIPTION
Update get jobs ordering to use descending updated_at.

Issue: https://github.com/optriment/optrispace-backend/issues/141.